### PR TITLE
target property | handle duplicity

### DIFF
--- a/src/modules/targetProperty/controllers/target-property.controller.ts
+++ b/src/modules/targetProperty/controllers/target-property.controller.ts
@@ -87,7 +87,7 @@ const createTargetPropertySchema = z.object({
 type CreateTargetProperty = z.infer<typeof createTargetPropertySchema>;
 
 const updateTargetPropertySchema = z.object({
-  adURL: z.string().optional(),
+  huntId: z.string(),
   sellPrice: z.number().optional(),
   rentPrice: z.number().optional(),
   iptu: z.number().optional(),
@@ -101,6 +101,7 @@ const updateTargetPropertySchema = z.object({
   visitDate: z.string().optional(),
 
   city: z.string().optional(),
+  country: z.string().optional(),
   uf: z.string().optional(),
   neighborhood: z.string().optional(),
 
@@ -288,11 +289,6 @@ export class TargetPropertyController {
   @UseGuards(AuthGuard)
   @Delete(':id')
   async deleteTargetProperty(@Param('id') id: string) {
-    const toDelete = await this.targetPropertyService.getOneTargetById(id);
-    const deleted = await this.targetPropertyService.deleteTargetProperty(id);
-
-    if (deleted) {
-      await this.huntService.removeTargetFromHunt(toDelete.huntId, id);
-    }
+    await this.targetPropertyService.deleteTargetProperty(id);
   }
 }

--- a/src/modules/targetProperty/repositories/mongoose/target-property.mongoose.repository.ts
+++ b/src/modules/targetProperty/repositories/mongoose/target-property.mongoose.repository.ts
@@ -69,6 +69,93 @@ export class TargetPropertyMongooseRepository
     return result;
   }
 
+  async getHuntTargetByFullAddress(
+    huntId: string,
+    address: Pick<
+      InterfaceTargetProperty,
+      | 'neighborhood'
+      | 'street'
+      | 'city'
+      | 'uf'
+      | 'country'
+      | 'lotNumber'
+      | 'propertyNumber'
+    >,
+  ): Promise<InterfaceTargetProperty> {
+    const foundProperties = await this.targetPropertyModel
+      .find({
+        huntId: huntId,
+        lotNumber: address.lotNumber,
+        propertyNumber: address.propertyNumber,
+        street: address.street,
+        neighborhood: address.neighborhood,
+        city: address.city,
+        uf: address.uf,
+        country: address.country,
+      })
+      .lean<LeanDoc<TargetProperty>[]>()
+      .exec();
+
+    if (foundProperties.length <= 0) {
+      return null;
+    }
+
+    return foundProperties[0];
+  }
+
+  async getHuntTargetsByLot(
+    huntId: string,
+    address: Pick<
+      InterfaceTargetProperty,
+      'neighborhood' | 'street' | 'city' | 'uf' | 'country' | 'lotNumber'
+    >,
+  ): Promise<InterfaceTargetProperty[]> {
+    const foundProperties = await this.targetPropertyModel
+      .find({
+        huntId: huntId,
+        lotNumber: address.lotNumber,
+        street: address.street,
+        neighborhood: address.neighborhood,
+        city: address.city,
+        uf: address.uf,
+        country: address.country,
+      })
+      .lean<LeanDoc<TargetProperty>[]>()
+      .exec();
+
+    if (foundProperties.length <= 0) {
+      return null;
+    }
+
+    return foundProperties;
+  }
+
+  async getHuntTargetsByStreet(
+    huntId: string,
+    address: Pick<
+      InterfaceTargetProperty,
+      'neighborhood' | 'street' | 'city' | 'uf' | 'country'
+    >,
+  ): Promise<InterfaceTargetProperty[]> {
+    const foundProperties = await this.targetPropertyModel
+      .find({
+        huntId: huntId,
+        street: address.street,
+        neighborhood: address.neighborhood,
+        city: address.city,
+        uf: address.uf,
+        country: address.country,
+      })
+      .lean<LeanDoc<TargetProperty>[]>()
+      .exec();
+
+    if (foundProperties.length <= 0) {
+      return null;
+    }
+
+    return foundProperties;
+  }
+
   async getOneTargetById(id: string): Promise<InterfaceTargetProperty> {
     const property = await this.targetPropertyModel
       .findById(id)

--- a/src/modules/targetProperty/repositories/target-property.repository.ts
+++ b/src/modules/targetProperty/repositories/target-property.repository.ts
@@ -9,6 +9,36 @@ export abstract class TargetPropertyRepository {
     limit?: number,
   ): Promise<PaginatedData<InterfaceTargetProperty>>;
 
+  abstract getHuntTargetByFullAddress(
+    huntId: string,
+    address: Pick<
+      InterfaceTargetProperty,
+      | 'neighborhood'
+      | 'street'
+      | 'city'
+      | 'uf'
+      | 'country'
+      | 'lotNumber'
+      | 'propertyNumber'
+    >,
+  ): Promise<InterfaceTargetProperty>;
+
+  abstract getHuntTargetsByLot(
+    huntId: string,
+    address: Pick<
+      InterfaceTargetProperty,
+      'neighborhood' | 'street' | 'city' | 'uf' | 'country' | 'lotNumber'
+    >,
+  ): Promise<InterfaceTargetProperty[]>;
+
+  abstract getHuntTargetsByStreet(
+    huntId: string,
+    address: Pick<
+      InterfaceTargetProperty,
+      'neighborhood' | 'street' | 'city' | 'uf' | 'country'
+    >,
+  ): Promise<InterfaceTargetProperty[]>;
+
   abstract getOneTargetById(id: string): Promise<InterfaceTargetProperty>;
 
   abstract createTargetProperty(

--- a/src/modules/targetProperty/schemas/target-property.schema.ts
+++ b/src/modules/targetProperty/schemas/target-property.schema.ts
@@ -94,7 +94,7 @@ export class TargetProperty implements InterfaceTargetProperty {
   block?: string;
   @ApiPropertyOptional()
   @Prop()
-  number?: string;
+  propertyNumber?: string;
   @ApiPropertyOptional()
   @Prop()
   size?: number;


### PR DESCRIPTION
Valida a existência do endereço de um target dentro da hunt

Retorna a informação para o front exibir o feedback para o usuário.

- create
- update